### PR TITLE
PDFダウンロード機能追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@types/react-dom": "18.2.7",
         "eslint": "8.48.0",
         "eslint-config-next": "13.4.19",
+        "html-to-image": "^1.11.11",
+        "jspdf": "^2.5.1",
         "next": "13.4.19",
         "re-resizable": "^6.9.11",
         "react": "18.2.0",
@@ -30,6 +32,7 @@
       },
       "devDependencies": {
         "@iconify/react": "^4.1.1",
+        "@types/jspdf": "^2.0.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-unused-imports": "^3.0.0",
@@ -1356,6 +1359,16 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "node_modules/@types/jspdf": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jspdf/-/jspdf-2.0.0.tgz",
+      "integrity": "sha512-oonYDXI4GegGaG7FFVtriJ+Yqlh4YR3L3NVDiwCEBVG7sbya19SoGx4MW4kg1MCMRPgkbbFTck8YKJL8PrkDfA==",
+      "deprecated": "This is a stub types definition. jspdf provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "jspdf": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.5.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
@@ -1370,6 +1383,12 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.2.tgz",
+      "integrity": "sha512-sM4HyDVlDFl4goOXPF+g9nNHJFZQGot+HgySjM4cRjqXzjdatcEvYrtG4Ia8XumR9T6k8G2tW9B7hnUj51Uf0A==",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.21",
@@ -1715,6 +1734,17 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -1761,6 +1791,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1779,6 +1818,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer-from": {
@@ -1835,6 +1885,31 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "optional": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1895,6 +1970,17 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
+    "node_modules/core-js": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.1.tgz",
+      "integrity": "sha512-qVSq3s+d4+GsqN0teRCJtM6tdEEXyWxjzbhVrCHmBS5ZTM0FS2MOS0D13dUXAWDUN6a+lHI/N1hF9Ytz6iLl9Q==",
+      "hasInstallScript": true,
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -1926,6 +2012,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -2108,6 +2203,12 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.7.tgz",
+      "integrity": "sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ==",
+      "optional": true
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -2774,6 +2875,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3102,6 +3208,11 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
+    },
     "node_modules/html-tokenize": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
@@ -3115,6 +3226,19 @@
       },
       "bin": {
         "html-tokenize": "bin/cmd.js"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ignore": {
@@ -3544,6 +3668,23 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -3986,6 +4127,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -4089,6 +4236,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/re-resizable": {
       "version": "6.9.11",
@@ -4320,6 +4476,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -4467,6 +4632,15 @@
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.6.0.tgz",
+      "integrity": "sha512-8S1aIA+UoF6erJYnglGPug6MaHYGo1Ot7h5fuXx4fUPvcvQfcdw2o/ppCse63+eZf8PPidSu4v1JnmEVtEDnpg==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
       }
     },
     "node_modules/streamsearch": {
@@ -4621,12 +4795,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -4823,6 +5015,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@types/react-dom": "18.2.7",
     "eslint": "8.48.0",
     "eslint-config-next": "13.4.19",
+    "html-to-image": "^1.11.11",
+    "jspdf": "^2.5.1",
     "next": "13.4.19",
     "re-resizable": "^6.9.11",
     "react": "18.2.0",
@@ -34,6 +36,7 @@
   },
   "devDependencies": {
     "@iconify/react": "^4.1.1",
+    "@types/jspdf": "^2.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-unused-imports": "^3.0.0",

--- a/src/components/mindmap/nodes/TextNode.tsx
+++ b/src/components/mindmap/nodes/TextNode.tsx
@@ -318,10 +318,7 @@ export const TextNode = memo<NodeProps>(({ data, isConnectable, selected }) => {
         </Paper>
       </NodeToolbar>
       {(["source"] as HandleType[]).map((type) => {
-        return [
-          Position.Bottom,
-          Position.Right,
-        ].map((position) => (
+        return [Position.Bottom, Position.Right].map((position) => (
           <Handle
             key={`${position}-${type}`}
             id={`${position}-${type}`}
@@ -333,10 +330,7 @@ export const TextNode = memo<NodeProps>(({ data, isConnectable, selected }) => {
         ));
       })}
       {(["target"] as HandleType[]).map((type) => {
-        return [
-          Position.Top,
-          Position.Left,
-        ].map((position) => (
+        return [Position.Top, Position.Left].map((position) => (
           <Handle
             key={`${position}-${type}`}
             id={`${position}-${type}`}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,6 +19,7 @@ import {
   Node,
   Panel,
   ReactFlow,
+  ReactFlowProvider,
   useEdgesState,
   useNodesState,
 } from "reactflow";
@@ -102,104 +103,106 @@ export default function Home() {
   }, [nodes, edges, selectedPageId]);
 
   return (
-    <Box sx={{ width: "100vw", height: "100vh", display: "flex" }}>
-      <Resizable
-        defaultSize={{
-          width: 300,
-          height: "calc(100vh -  5px)",
-        }}
-        enable={{
-          right: true,
-        }}
-      >
-        <Box
-          sx={{
-            width: "100%",
-            height: "100%",
-            borderRight: 1,
-            borderColor: "divider",
+    <ReactFlowProvider>
+      <Box sx={{ width: "100vw", height: "100vh", display: "flex" }}>
+        <Resizable
+          defaultSize={{
+            width: 300,
+            height: "calc(100vh -  5px)",
+          }}
+          enable={{
+            right: true,
           }}
         >
-          <Toolbar variant={ToolbarVariant} />
-          <List
-            sx={{ mt: 2 }}
-            subheader={
-              <ListSubheader
-                sx={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                }}
-              >
-                Pages
-                <Box>
-                  <IconButton
-                    size={"small"}
-                    onClick={() => {
-                      dispatch(addPage());
-                    }}
-                  >
-                    <Add fontSize={"inherit"} />
-                  </IconButton>
-                </Box>
-              </ListSubheader>
-            }
-            dense
+          <Box
+            sx={{
+              width: "100%",
+              height: "100%",
+              borderRight: 1,
+              borderColor: "divider",
+            }}
           >
-            {pages.map((page) => (
-              <ListItemButton
-                key={page.id}
-                selected={page.id === selectedPageId}
-                onClick={() => {
-                  applyState();
-                  dispatch(selectPage(page.id));
-                }}
-              >
-                {page.name}
-              </ListItemButton>
-            ))}
-          </List>
-        </Box>
-      </Resizable>
-      <ReactFlow
-        nodeTypes={nodeTypes}
-        nodes={nodes}
-        onNodesChange={onNodesChange}
-        edges={edges}
-        onEdgesChange={onEdgesChange}
-        onConnect={onConnect}
-      >
-        <Panel
-          position={"top-left"}
-          style={{
-            margin: 0,
-          }}
-        >
-          <Box sx={{ flexGrow: 1 }}>
-            <MindmapToolbar
-              onAddNode={(type) => {
-                setNodes((nodes) => [
-                  ...nodes,
-                  {
-                    id: crypto.randomUUID(),
-                    type,
-                    position: {
-                      x: 250,
-                      y: 250,
-                    },
-                    data: {
-                      label: "Text",
-                      onChange: handleNodeChange,
-                    },
-                  },
-                ]);
-              }}
-            />
+            <Toolbar variant={ToolbarVariant} />
+            <List
+              sx={{ mt: 2 }}
+              subheader={
+                <ListSubheader
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                  }}
+                >
+                  Pages
+                  <Box>
+                    <IconButton
+                      size={"small"}
+                      onClick={() => {
+                        dispatch(addPage());
+                      }}
+                    >
+                      <Add fontSize={"inherit"} />
+                    </IconButton>
+                  </Box>
+                </ListSubheader>
+              }
+              dense
+            >
+              {pages.map((page) => (
+                <ListItemButton
+                  key={page.id}
+                  selected={page.id === selectedPageId}
+                  onClick={() => {
+                    applyState();
+                    dispatch(selectPage(page.id));
+                  }}
+                >
+                  {page.name}
+                </ListItemButton>
+              ))}
+            </List>
           </Box>
-        </Panel>
-        <Controls />
-        <MiniMap />
-        <Background variant={BackgroundVariant.Dots} gap={10} size={1} />
-      </ReactFlow>
-    </Box>
+        </Resizable>
+        <ReactFlow
+          nodeTypes={nodeTypes}
+          nodes={nodes}
+          onNodesChange={onNodesChange}
+          edges={edges}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+        >
+          <Panel
+            position={"top-left"}
+            style={{
+              margin: 0,
+            }}
+          >
+            <Box sx={{ flexGrow: 1 }}>
+              <MindmapToolbar
+                onAddNode={(type) => {
+                  setNodes((nodes) => [
+                    ...nodes,
+                    {
+                      id: crypto.randomUUID(),
+                      type,
+                      position: {
+                        x: 250,
+                        y: 250,
+                      },
+                      data: {
+                        label: "Text",
+                        onChange: handleNodeChange,
+                      },
+                    },
+                  ]);
+                }}
+              />
+            </Box>
+          </Panel>
+          <Controls />
+          <MiniMap />
+          <Background variant={BackgroundVariant.Dots} gap={10} size={1} />
+        </ReactFlow>
+      </Box>
+    </ReactFlowProvider>
   );
 }


### PR DESCRIPTION
[react-flow](https://reactflow.dev/)で描画したフロー図を[html-to-image](https://github.com/bubkoo/html-to-image)を使用してPNGに変換し、[jspdf](https://github.com/parallax/jsPDF)でPDFに変換してダウンロードするように修正。

参考: https://reactflow.dev/docs/examples/misc/download-image/